### PR TITLE
Improve dashboard UI with logo

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ import uuid
 
 # --- Timesheet helpers ---
 TASKS_FILE = "tasks.csv"
+LOGO = "/assets/logo.svg"
 
 def load_tasks():
     if os.path.exists(TASKS_FILE):
@@ -223,8 +224,31 @@ dashboard_layout = dbc.Container([
 ], fluid=False)
 
 # --- Dash App ---
-app = Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP], meta_tags=[{"name": "viewport", "content": "width=device-width, initial-scale=1"}])
+app = Dash(
+    __name__,
+    external_stylesheets=[dbc.themes.LUX],
+    meta_tags=[{"name": "viewport", "content": "width=device-width, initial-scale=1"}],
+)
 app.title = "Sharp Token Dashboard"
+
+# Navigation bar with logo
+navbar = dbc.Navbar(
+    dbc.Container(
+        [
+            dbc.Row(
+                [
+                    dbc.Col(html.Img(src=LOGO, height="40px")),
+                    dbc.Col(dbc.NavbarBrand("Sharp Token Dashboard", className="ms-2")),
+                ],
+                align="center",
+                className="g-0",
+            ),
+        ]
+    ),
+    color="primary",
+    dark=True,
+    className="mb-4",
+)
 
 def timesheet_layout():
     unique_names = sorted(tasks_df["name"].dropna().unique().tolist())
@@ -297,6 +321,7 @@ def timesheet_layout():
     ], fluid=False)
 
 app.layout = html.Div([
+    navbar,
     dcc.Tabs([
         dcc.Tab(label="Dashboard", children=dashboard_layout),
         dcc.Tab(label="Timesheet", children=timesheet_layout()),

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,4 @@
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="50" cy="50" r="45" fill="#4A90E2" />
+  <text x="50" y="65" text-anchor="middle" font-size="60" font-family="Arial" font-weight="bold" fill="white">S</text>
+</svg>

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,1 @@
+body { font-family: Arial, sans-serif; }


### PR DESCRIPTION
## Summary
- update app to use a modern Bootstrap theme
- add a navigation bar with the Sharp logo
- include logo SVG and basic CSS styling

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686bbc16624883288ec9ba4774ee7faa