### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,9 @@ import uuid
 
 LOGO = "/assets/logo.svg"
 
+GRAPH_STYLE = {"width": "100%", "height": "100%"}
+GRAPH_CONFIG = {"responsive": True}
+
 # --- Load data ---
 df = {k.strip(): v for k, v in pd.read_excel("Sharp Token.xlsx", sheet_name=None).items()}
 
@@ -167,18 +170,18 @@ token_bar, token_line, wallet_bar, wallet_pie, referral_bar, referral_line, fee_
 
 dashboard_layout = dbc.Container([
     html.H2("Sharp Token Dashboard", className="my-4 text-center"),
-    dbc.Row([dbc.Col(dcc.Graph(figure=token_bar), width=12)], className="mb-4"),
-    dbc.Row([dbc.Col(dcc.Graph(figure=token_line), width=12)], className="mb-4"),
-    dbc.Row([dbc.Col(dcc.Graph(figure=wallet_bar), width=12)], className="mb-4"),
+    dbc.Row(dbc.Col(dbc.Card(dbc.CardBody(dcc.Graph(figure=token_bar, style=GRAPH_STYLE, config=GRAPH_CONFIG))), width=12), className="mb-4"),
+    dbc.Row(dbc.Col(dbc.Card(dbc.CardBody(dcc.Graph(figure=token_line, style=GRAPH_STYLE, config=GRAPH_CONFIG))), width=12), className="mb-4"),
+    dbc.Row(dbc.Col(dbc.Card(dbc.CardBody(dcc.Graph(figure=wallet_bar, style=GRAPH_STYLE, config=GRAPH_CONFIG))), width=12), className="mb-4"),
     dbc.Row([
-        dbc.Col(dcc.Graph(figure=wallet_pie), md=6),
-        dbc.Col(dcc.Graph(figure=token_source_bar), md=6)
+        dbc.Col(dbc.Card(dbc.CardBody(dcc.Graph(figure=wallet_pie, style=GRAPH_STYLE, config=GRAPH_CONFIG))), md=6),
+        dbc.Col(dbc.Card(dbc.CardBody(dcc.Graph(figure=token_source_bar, style=GRAPH_STYLE, config=GRAPH_CONFIG))), md=6)
     ], className="mb-4"),
-    dbc.Row([dbc.Col(dcc.Graph(figure=referral_bar), width=12)], className="mb-4"),
-    dbc.Row([dbc.Col(dcc.Graph(figure=referral_line), width=12)], className="mb-4"),
-    dbc.Row([dbc.Col(dcc.Graph(figure=fee_line), width=12)], className="mb-4"),
-    dbc.Row([dbc.Col(dcc.Graph(figure=fig_pies), width=12)], className="mb-4"),
-], fluid=False)
+    dbc.Row(dbc.Col(dbc.Card(dbc.CardBody(dcc.Graph(figure=referral_bar, style=GRAPH_STYLE, config=GRAPH_CONFIG))), width=12), className="mb-4"),
+    dbc.Row(dbc.Col(dbc.Card(dbc.CardBody(dcc.Graph(figure=referral_line, style=GRAPH_STYLE, config=GRAPH_CONFIG))), width=12), className="mb-4"),
+    dbc.Row(dbc.Col(dbc.Card(dbc.CardBody(dcc.Graph(figure=fee_line, style=GRAPH_STYLE, config=GRAPH_CONFIG))), width=12), className="mb-4"),
+    dbc.Row(dbc.Col(dbc.Card(dbc.CardBody(dcc.Graph(figure=fig_pies, style=GRAPH_STYLE, config=GRAPH_CONFIG))), width=12), className="mb-4"),
+], fluid=True)
 
 # --- Dash App ---
 app = Dash(
@@ -210,9 +213,7 @@ navbar = dbc.Navbar(
 
 app.layout = html.Div([
     navbar,
-    dcc.Tabs([
-        dcc.Tab(label="Dashboard", children=dashboard_layout),
-    ])
+    dashboard_layout
 ])
 
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,1 +1,18 @@
-body { font-family: Arial, sans-serif; }
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  overflow-x: hidden;
+}
+
+@media (max-width: 576px) {
+  .navbar-brand {
+    font-size: 1rem;
+  }
+  .card {
+    margin-bottom: 0.75rem !important;
+  }
+  .card-body {
+    padding: 0.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- tweak CSS for better mobile layout
- add shared graph style and apply to all charts

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686cd933f3288328b1339c2e35c66987